### PR TITLE
fix: Mobile nav overflow fix

### DIFF
--- a/src/components/Header.scss
+++ b/src/components/Header.scss
@@ -40,6 +40,8 @@
   
   &__nav {
     display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
     align-items: center;
     gap: 0.75rem;
   }


### PR DESCRIPTION
There was a header overflow issue caused by missing wrap condition on a `flex` 

**Changes:**

- Added  `flex-wrap: wrap` to ensure the nav doesn't overflow
- Added `justify-contend: flex-end` for alignment

| Before | Now |
|--------|--------|
| <img width="426" height="914" alt="image" src="https://github.com/user-attachments/assets/8a3f4159-3a26-42fa-ab14-2865858f6276" />| <img width="419" height="911" alt="image" src="https://github.com/user-attachments/assets/3ca19dc8-2bd8-4fa4-bc72-7b7b7d7d1504" />| 