### PR TITLE
feat: added "meetups" to CanConf

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,8 +29,8 @@
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image" />
     <meta property="twitter:url" content="https://tjklint.github.io/CanConf/" />
-    <meta property="twitter:title" content="CanConf - Canadian Tech Conferences & Hackathons Directory" />
-    <meta property="twitter:description" content="Discover Canadian tech conferences, hackathons, and events across all provinces. Find student-friendly programming competitions and connect with Canada's tech community." />
+    <meta property="twitter:title" content="CanConf - Canadian Tech Conferences, Hackathons & Meetups Directory" />
+    <meta property="twitter:description" content="Discover Canadian tech conferences, hackathons, and meetups across all provinces. Find student-friendly programming competitions, developer meetups, and connect with Canada's tech community." />
     <meta property="twitter:image" content="https://tjklint.github.io/CanConf/og-image.png" />
     <meta property="twitter:creator" content="@tjklint" />
     

--- a/index.html
+++ b/index.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     
     <!-- Primary Meta Tags -->
-    <title>CanConf - Canadian Tech Conferences & Hackathons Directory</title>
-    <meta name="title" content="CanConf - Canadian Tech Conferences & Hackathons Directory" />
-    <meta name="description" content="Discover Canadian tech conferences, hackathons, and events across all provinces. Find student-friendly programming competitions, AI conferences, cybersecurity events, and more. Connect with Canada's tech community." />
+    <title>CanConf - Canadian Tech Conferences, Hackathons & Meetups Directory</title>
+    <meta name="title" content="CanConf - Canadian Tech Conferences, Hackathons & Meetups Directory" />
+    <meta name="description" content="Discover Canadian tech conferences, hackathons, and meetups across all provinces. Find student-friendly programming competitions, AI conferences, cybersecurity events, developer meetups, and more. Connect with Canada's tech community." />
     <meta name="keywords" content="Canadian tech events, hackathons Canada, tech conferences Canada, programming competitions, student hackathons, AI conferences, cybersecurity events, tech meetups, MLH events, Toronto hackathons, Vancouver tech, Montreal conferences" />
     <meta name="author" content="TJ - CanConf" />
     <meta name="robots" content="index, follow" />
@@ -18,8 +18,8 @@
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://tjklint.github.io/CanConf/" />
-    <meta property="og:title" content="CanConf - Canadian Tech Conferences & Hackathons Directory" />
-    <meta property="og:description" content="Discover Canadian tech conferences, hackathons, and events across all provinces. Find student-friendly programming competitions and connect with Canada's tech community." />
+    <meta property="og:title" content="CanConf - Canadian Tech Conferences, Hackathons & Meetups Directory" />
+    <meta property="og:description" content="Discover Canadian tech conferences, hackathons, and meetups across all provinces. Find student-friendly programming competitions, developer meetups, and connect with Canada's tech community." />
     <meta property="og:image" content="https://tjklint.github.io/CanConf/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />

--- a/src/components/EventSection.scss
+++ b/src/components/EventSection.scss
@@ -117,6 +117,24 @@
   }
 }
 
+// Tablet view - stack meetups below conferences and hackathons
+@media (max-width: 1024px) and (min-width: 769px) {
+  .event-section {
+    &__content {
+      flex-wrap: wrap;
+      
+      .event-section__column:nth-child(5) { // Meetups column (with dividers, it's the 5th child)
+        flex-basis: 100%;
+        margin-top: 1rem;
+      }
+      
+      .event-section__divider:nth-child(4) { // Divider before meetups
+        display: none;
+      }
+    }
+  }
+}
+
 @media (max-width: 768px) {
   .event-section {
     padding: 1rem;

--- a/src/components/EventSection.scss
+++ b/src/components/EventSection.scss
@@ -41,7 +41,7 @@
   
   &__content {
     display: flex;
-    gap: 2rem;
+    gap: 1.5rem;
   }
   
   &__column {

--- a/src/components/EventSection.tsx
+++ b/src/components/EventSection.tsx
@@ -57,9 +57,15 @@ const EventSection = ({ events, selectedProvince, onProvinceChange }: EventSecti
     [events, hackathonSearch, filterAndSortEvents]
   );
 
+  const filteredMeetups = useMemo(() => 
+    filterAndSortEvents(events, meetupSearch, 'meetup'), 
+    [events, meetupSearch, filterAndSortEvents]
+  );
+
   // Limit displayed events to 5 unless "show all" is toggled
   const displayedConferences = showAllConferences ? filteredConferences : filteredConferences.slice(0, 5);
   const displayedHackathons = showAllHackathons ? filteredHackathons : filteredHackathons.slice(0, 5);
+  const displayedMeetups = showAllMeetups ? filteredMeetups : filteredMeetups.slice(0, 5);
 
   const renderEventColumn = (
     title: string,

--- a/src/components/EventSection.tsx
+++ b/src/components/EventSection.tsx
@@ -165,6 +165,19 @@ const EventSection = ({ events, selectedProvince, onProvinceChange }: EventSecti
           showAllHackathons,
           setShowAllHackathons
         )}
+
+        <div className="event-section__divider"></div>
+        
+        {renderEventColumn(
+          'Meetups',
+          displayedMeetups,
+          filteredMeetups,
+          meetupSearch,
+          setMeetupSearch,
+          'Search meetups... (City, Name, Tags)',
+          showAllMeetups,
+          setShowAllMeetups
+        )}
       </div>
     </div>
   );

--- a/src/components/EventSection.tsx
+++ b/src/components/EventSection.tsx
@@ -15,11 +15,13 @@ interface EventSectionProps {
 const EventSection = ({ events, selectedProvince, onProvinceChange }: EventSectionProps) => {
   const [conferenceSearch, setConferenceSearch] = useState('');
   const [hackathonSearch, setHackathonSearch] = useState('');
+  const [meetupSearch, setMeetupSearch] = useState('');
   const [activeTab, setActiveTab] = useState<'upcoming' | 'past'>('upcoming');
   const [showAllConferences, setShowAllConferences] = useState(false);
   const [showAllHackathons, setShowAllHackathons] = useState(false);
+  const [showAllMeetups, setShowAllMeetups] = useState(false);
 
-  const filterAndSortEvents = useCallback((events: EventType[], searchQuery: string, eventType: 'conference' | 'hackathon') => {
+  const filterAndSortEvents = useCallback((events: EventType[], searchQuery: string, eventType: 'conference' | 'hackathon' | 'meetup') => {
     // Filter by event type
     const filteredEvents = events.filter(event => event.type === eventType);
     

--- a/src/data/events.json
+++ b/src/data/events.json
@@ -411,16 +411,6 @@
       "isStudentFocused": false
     },
     {
-      "name": "Vancouver ReactJS Meetup",
-      "date": "September 5, 2025",
-      "location": "Vancouver, BC",
-      "website": "https://www.meetup.com/reactjs-vancouver/",
-      "province": "BC",
-      "type": "meetup",
-      "tags": ["react", "javascript", "frontend", "jsx", "hooks", "community", "weekly"],
-      "isStudentFocused": false
-    },
-    {
       "name": "Montreal Python User Group",
       "date": "September 10, 2025",
       "location": "Montreal, QC",
@@ -468,36 +458,6 @@
       "province": "BC",
       "type": "meetup",
       "tags": ["technology", "startup", "innovation", "networking", "community", "bi-weekly"],
-      "isStudentFocused": false
-    },
-    {
-      "name": "Toronto Machine Learning Society",
-      "date": "September 30, 2025",
-      "location": "Toronto, ON",
-      "website": "https://www.meetup.com/toronto-machine-learning-society/",
-      "province": "ON",
-      "type": "meetup",
-      "tags": ["machine learning", "ai", "data science", "tensorflow", "pytorch", "research", "monthly"],
-      "isStudentFocused": false
-    },
-    {
-      "name": "Halifax Developer Meetup",
-      "date": "October 2, 2025",
-      "location": "Halifax, NS",
-      "website": "https://www.meetup.com/halifax-developer-meetup/",
-      "province": "NS",
-      "type": "meetup",
-      "tags": ["web development", "mobile", "software engineering", "community", "networking", "monthly"],
-      "isStudentFocused": false
-    },
-    {
-      "name": "Winnipeg .NET User Group",
-      "date": "October 5, 2025",
-      "location": "Winnipeg, MB",
-      "website": "https://www.meetup.com/winnipeg-net-user-group/",
-      "province": "MB",
-      "type": "meetup",
-      "tags": [".net", "c#", "asp.net", "microsoft", "enterprise", "community", "monthly"],
       "isStudentFocused": false
     }
   ]

--- a/src/data/events.json
+++ b/src/data/events.json
@@ -399,6 +399,106 @@
       "type": "conference",
       "tags": ["google", "ai", "artificial intelligence", "networking", "cloud", "social good", "workshops", "community", "innovation", "social-good", "winnipeg", "west-coast"],
       "isStudentFocused": false
+    },
+    {
+      "name": "Toronto JavaScript Meetup",
+      "date": "August 25, 2025",
+      "location": "Toronto, ON",
+      "website": "https://www.meetup.com/torontojs/",
+      "province": "ON",
+      "type": "meetup",
+      "tags": ["javascript", "frontend", "backend", "nodejs", "react", "community", "networking", "monthly"],
+      "isStudentFocused": false
+    },
+    {
+      "name": "Vancouver ReactJS Meetup",
+      "date": "September 5, 2025",
+      "location": "Vancouver, BC",
+      "website": "https://www.meetup.com/reactjs-vancouver/",
+      "province": "BC",
+      "type": "meetup",
+      "tags": ["react", "javascript", "frontend", "jsx", "hooks", "community", "weekly"],
+      "isStudentFocused": false
+    },
+    {
+      "name": "Montreal Python User Group",
+      "date": "September 10, 2025",
+      "location": "Montreal, QC",
+      "website": "https://www.meetup.com/montreal-python/",
+      "province": "QC",
+      "type": "meetup",
+      "tags": ["python", "data science", "machine learning", "django", "flask", "community", "monthly"],
+      "isStudentFocused": false
+    },
+    {
+      "name": "Calgary Software Crafters",
+      "date": "September 15, 2025",
+      "location": "Calgary, AB",
+      "website": "https://www.meetup.com/calgary-software-crafters/",
+      "province": "AB",
+      "type": "meetup",
+      "tags": ["software engineering", "clean code", "tdd", "agile", "craftsmanship", "community", "bi-weekly"],
+      "isStudentFocused": false
+    },
+    {
+      "name": "Ottawa Java User Group",
+      "date": "September 18, 2025",
+      "location": "Ottawa, ON",
+      "website": "https://www.meetup.com/ottawa-java-user-group/",
+      "province": "ON",
+      "type": "meetup",
+      "tags": ["java", "spring", "microservices", "enterprise", "jvm", "community", "monthly"],
+      "isStudentFocused": false
+    },
+    {
+      "name": "Toronto DevOps Meetup",
+      "date": "September 20, 2025",
+      "location": "Toronto, ON",
+      "website": "https://www.meetup.com/toronto-devops/",
+      "province": "ON",
+      "type": "meetup",
+      "tags": ["devops", "kubernetes", "docker", "aws", "azure", "ci/cd", "infrastructure", "monthly"],
+      "isStudentFocused": false
+    },
+    {
+      "name": "Vancouver Tech Meetup",
+      "date": "September 25, 2025",
+      "location": "Vancouver, BC",
+      "website": "https://www.meetup.com/vancouver-tech-meetup/",
+      "province": "BC",
+      "type": "meetup",
+      "tags": ["technology", "startup", "innovation", "networking", "community", "bi-weekly"],
+      "isStudentFocused": false
+    },
+    {
+      "name": "Toronto Machine Learning Society",
+      "date": "September 30, 2025",
+      "location": "Toronto, ON",
+      "website": "https://www.meetup.com/toronto-machine-learning-society/",
+      "province": "ON",
+      "type": "meetup",
+      "tags": ["machine learning", "ai", "data science", "tensorflow", "pytorch", "research", "monthly"],
+      "isStudentFocused": false
+    },
+    {
+      "name": "Halifax Developer Meetup",
+      "date": "October 2, 2025",
+      "location": "Halifax, NS",
+      "website": "https://www.meetup.com/halifax-developer-meetup/",
+      "province": "NS",
+      "type": "meetup",
+      "tags": ["web development", "mobile", "software engineering", "community", "networking", "monthly"],
+      "isStudentFocused": false
+    },
+    {
+      "name": "Winnipeg .NET User Group",
+      "date": "October 5, 2025",
+      "location": "Winnipeg, MB",
+      "website": "https://www.meetup.com/winnipeg-net-user-group/",
+      "province": "MB",
+      "type": "meetup",
+      "tags": [".net", "c#", "asp.net", "microsoft", "enterprise", "community", "monthly"],
+      "isStudentFocused": false
     }
   ]
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,7 +4,7 @@ export interface Event {
   location: string;
   website: string;
   province: string;
-  type: 'conference' | 'hackathon';
+  type: 'conference' | 'hackathon' | 'meetup';
   tags: string[];
   isStudentFocused: boolean;
 }


### PR DESCRIPTION
A recommendation by @nicoespeon, as meetups don't quite fit the traditional "conference" name.

I haven't quite came up with a strict differenciation between conference and meetups, and I still think there's a TON of nuance between the two, overall, I don't think that it's too big of a deal. People looking for a "react" event will likely search through all 3 types of events anyway.

Thanks!