### PR TITLE
Add a hackathon and a meetup in Ottawa

### DIFF
--- a/src/data/events.json
+++ b/src/data/events.json
@@ -1297,6 +1297,54 @@
         "conference"
       ],
       "isStudentFocused": true
+    },
+
+    {
+      "name": "World's First \"Situation Dashboard\" Hachathon",
+      "date": "January 24, 2026",
+      "location": "Ottawa, Ontario",
+      "website": "https://luma.com/xcg7pg2p",
+      "province": "ON",
+      "type": "hackathon",
+      "tags": [
+        "student",
+        "canada",
+        "ottawa",
+        "programming",
+        "hackathon", 
+        "ontario", 
+        "claude", 
+        "prize", 
+        "competition",
+        "ai"
+      ],
+      "isStudentFocused": true
+    }, 
+
+    {
+      "name": "Builder Sundays",
+      "date": "January 25, 2026",
+      "location": "Ottawa, Ontario",
+      "website": "https://luma.com/mjtlvs6v?tk=cX2Qi6",
+      "province": "ON",
+      "type": "meetup",
+      "tags": [
+        "canada",
+        "meetup",
+        "ottawa",
+        "programming",
+        "ontario", 
+        "co-working", 
+        "networking",
+        "community"
+      ],
+      "isStudentFocused": true,
+      "isProfessional": true,
+      "isBeginnerFocused": true
     }
+
+
   ]
+
+  
 }


### PR DESCRIPTION
## Events Added

This PR adds two new tech events in Ottawa, Ontario:

### 1. World's First "Situation Dashboard" Hackathon
- **Date:** January 24, 2026
- **Location:** Ottawa, Ontario
- **Type:** Hackathon
- **Website:** https://luma.com/xcg7pg2p
- **Focus:** Student-focused hackathon with AI/Claude theme, prizes, and competition
- **Tags:** student, hackathon, programming, ai, claude, competition, prize, ottawa, ontario

### 2. Builder Sundays
- **Date:** January 25, 2026
- **Location:** Ottawa, Ontario
- **Type:** Meetup
- **Website:** https://luma.com/mjtlvs6v?tk=cX2Qi6
- **Focus:** Co-working meetup for students, beginners, and professionals
- **Tags:** meetup, networking, co-working, community, ottawa, ontario
